### PR TITLE
[Proposal] Load a default value for the field if present

### DIFF
--- a/app/views/providers/_options_fields.html.erb
+++ b/app/views/providers/_options_fields.html.erb
@@ -2,7 +2,7 @@
   <% provider_options.each do |key, value| %>
     <div class="field">
       <%= builder.label value[:name] %><br/>
-      <%= builder.text_field key %>
+      <%= builder.text_field key, value: value[:default] %>
     </div>
   <% end %>
 <% end %>


### PR DESCRIPTION
I believe it would be more user friendly if we could set the default value to be shown for various options. To set the default value one just have to add the default key to the hash.

``` ruby
:results=>{name: "Max results (200)", description: "Specify the number of results to retrieve", required: false, default: 100}
```
