### PR TITLE
Improve email notifications

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -14,12 +14,12 @@
 
 
 class NotificationMailer < ActionMailer::Base
-  default from: "scumblr@scumblr.com"
+  default from: "scumblr@localhost"
 
   def notification(recipients, subject, content)
     attachments['logo.png'] = File.read("#{Rails.root}/app/assets/images/scumblr_logo.png")
     @content = content
-    mail(:to=> "scumblr@scumblr.com", :bcc=> recipients, :subject=>subject)
+    mail(:bcc=> recipients, :subject=>subject)
   end
 
 

--- a/app/mailers/summary_mailer.rb
+++ b/app/mailers/summary_mailer.rb
@@ -14,7 +14,7 @@
 
 
 class SummaryMailer < ActionMailer::Base
-  default from: "scumblr@scumblr.com"
+  default from: "scumblr@localhost"
 
   def notification(recipients, filter, results)
     attachments['logo.png'] = File.read("#{Rails.root}/app/assets/images/scumblr_logo.png")
@@ -22,7 +22,7 @@ class SummaryMailer < ActionMailer::Base
     @results = results
     @filter = filter
     subject = "Scumblr: Daily update for: #{@filter.name}"
-    mail(:to=> "scumblr@scumblr.com", :bcc=> recipients, :subject=>subject)
+    mail(:bcc=> recipients, :subject=>subject)
   end
 
 

--- a/app/views/results/_results_table.html.erb
+++ b/app/views/results/_results_table.html.erb
@@ -30,7 +30,7 @@
             </ul>
           <% end %>
         </td>
-        <% if result.present? %>
+        <% if result.title.present? %>
           <td><%= result.title.truncate(100, :separator=>' ') %></td>
         <% else %>
           <td>No Title</td>

--- a/app/views/results/_results_table.html.erb
+++ b/app/views/results/_results_table.html.erb
@@ -30,7 +30,11 @@
             </ul>
           <% end %>
         </td>
-        <td><%= result.title.truncate(100, :separator=>' ') %></td>
+        <% if result.present? %>
+          <td><%= result.title.truncate(100, :separator=>' ') %></td>
+        <% else %>
+          <td>No Title</td>
+        <% end %>
         <td><%= result.status %></td>
         <td><%= begin URI.parse(result.url).host rescue "" end %></td>
         <td><%= link_to "Link", result.url, data: {confirm: "Are you sure? This will take you to a potentially dangerous site!\n\nURL: " + result.url.to_s}, target:"_blank"  %></td>

--- a/app/views/summary_mailer/notification.html.erb
+++ b/app/views/summary_mailer/notification.html.erb
@@ -370,7 +370,11 @@
                                       <% @results.each do |result| %>
                                         <tr>
                                           <td><%= link_to result.id, result_url(result) %></td>
-                                          <td><%= link_to result.title.truncate(70, :separator=>' '), result.url %></td>
+                                          <% if result.present? %>
+                                            <td><%= link_to result.title.truncate(70, :separator=>' '), result.url %></td>
+                                          <% else %>
+                                            <td><%= link_to "No Title", result.url %></td>
+                                          <% end %>
                                           <td><%= result.domain %></td>
                                           <td><%= result.searches.try(:first).try(:name) %></td>
                                         </tr>

--- a/app/views/summary_mailer/notification.html.erb
+++ b/app/views/summary_mailer/notification.html.erb
@@ -370,7 +370,7 @@
                                       <% @results.each do |result| %>
                                         <tr>
                                           <td><%= link_to result.id, result_url(result) %></td>
-                                          <% if result.present? %>
+                                          <% if result.title.present? %>
                                             <td><%= link_to result.title.truncate(70, :separator=>' '), result.url %></td>
                                           <% else %>
                                             <td><%= link_to "No Title", result.url %></td>


### PR DESCRIPTION
While playing with a copy of Scumblr for testing purposes, I noticed that email notifications would all route to scumblr@scumblr.com. This did not appear to be desirable behavior for the following reasons:

1. All private deployments would notify this email, which is likely not what the end user intends.
2. This mail account is not routable when an email is sent to it directly.
3. The domain appears to be registered privately, and that private user may be able to read scans provided by Scumblr forks.

I removed this To: line from the mail rule entirely, instead just BCCing all notification contacts.

Using similar reasoning, I made the default return address scumblr@localhost. This seemed like the safest option for a non-routable email address, as even sites like example.org (https://tools.ietf.org/html/rfc2606) would still attempt to route via SMTP.

I also fixed a bug where Scumblr could, in some circumstances, provide search results that contained no title. This would break both the web interface for results display and email notifications.