### PR TITLE
add Github search provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'koala'
 #Database gems
 gem 'sqlite3'
 gem 'pg'
+gem 'mysql2'
 
 #OneLogin Authenticatable
 #gem 'devise_saml_authenticatable'

--- a/lib/search_providers/github.rb
+++ b/lib/search_providers/github.rb
@@ -1,0 +1,50 @@
+#     Copyright 2014 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+
+require 'uri'
+require 'net/http'
+require 'json'
+
+class SearchProvider::Github < SearchProvider::Provider
+  def self.provider_name
+    "Github Search"
+  end
+
+  def self.options
+    {}
+  end
+
+  def initialize(query, options={})
+    super
+  end
+
+  def run
+    url = URI.escape('https://api.github.com/search/repositories?q=' + @query)
+    response = Net::HTTP.get_response(URI(url))
+    results = []
+    if response.code == "200"
+      search_results = JSON.parse(response.body)
+      search_results['items'].each do |result|
+        results <<
+        {
+          :title => result['name'],
+          :url => result['html_url'],
+          :domain => "github.com"
+        }
+      end
+    end
+    return results
+  end
+end


### PR DESCRIPTION
Just a basic Search Provider for searching Github repositories. Feel free to include. 

Sadly wanted to search Gists by term, but doesn't appear Github's API supports that.

Edit: Also included mysql2 gem in Gemfile - wasn't meant to be part of pull request, oops!