### PR TITLE
remove duplicate feed_url options from RSS search provider

### DIFF
--- a/lib/search_providers/rss.rb
+++ b/lib/search_providers/rss.rb
@@ -26,18 +26,11 @@ class SearchProvider::RSS < SearchProvider::Provider
   def self.options
     {
       :feed_url=>{name: "RSS Feed URL", description: "The location of the RSS feed", required: true},
-      :feed_url=>{name: "RSS Feed URL", description: "The location of the RSS feed", required: true},
-      :feed_url=>{name: "RSS Feed URL", description: "The location of the RSS feed", required: true},      
-
     }
   end
 
   def initialize(query, options={})
     super
-    #Delete blank options (since Rails will save blank string if the option is not specified)
-    
-
-
   end
 
   def run


### PR DESCRIPTION
The RSS provider had 3x 'feed_url' options - assuming only one is necessary. Cleaned up.