### PR TITLE
Fix: Facebook Search Deprecation.

### DIFF
--- a/lib/search_providers/facebook.rb
+++ b/lib/search_providers/facebook.rb
@@ -12,62 +12,61 @@
 #     See the License for the specific language governing permissions and
 #     limitations under the License.
 
-
 require 'uri'
 
-class SearchProvider::Facebook < SearchProvider::Provider
-  def self.provider_name
-    "Facebook Search"
-  end
-
-  def self.options
-    {}
-  end
-
-  def initialize(query, options={})
-    super
-    app_id = Rails.configuration.try(:facebook_app_id)
-    app_secret = Rails.configuration.try(:facebook_app_secret)
-    oauth = Koala::Facebook::OAuth.new(app_id, app_secret)
-    @access_token = oauth.get_app_access_token
-  end
-
-  def run
-
-    if(@access_token.blank?)
-      Rails.logger.error "Unable to search Facebook. No access token. Please define an app id and app secret as facebook_app_id and facebook_app_secret in the Scumblr initializer."
-      return
+module SearchProvider
+  class Facebook < SearchProvider::Provider
+    def self.provider_name
+      'Facebook Search'.freeze
     end
 
+    def self.options
+      {}
+    end
 
-    @graph = Koala::Facebook::API.new(@access_token)
-    search_results = @graph.search(@query).map do |result|
-      {   :post_id => 'https://www.facebook.com/' + result['id'].to_s.gsub!(/_/, '/posts/'),
-        :user_id => result['from']['id'],
-        :published => result['created_time'].to_s,
-        :caption => (result['caption'] || ""),
-        :message => (result['message'] || ""),
-        :parsed_uri => (result['message'].nil? ? "" : URI.extract(result['message'], ['http', 'https']).join(' '))
+    def initialize(query, options = {})
+      super
+      app_id = Rails.configuration.try(:facebook_app_id)
+      app_secret = Rails.configuration.try(:facebook_app_secret)
+      oauth = Koala::Facebook::OAuth.new(app_id, app_secret)
+      @access_token = oauth.get_app_access_token
+    end
+
+    def run
+      if @access_token.blank?
+        Rails.logger.error 'Unable to search Facebook. No access token.
+                            Please define an app id and app secret as facebook_app_id and facebook_app_secret in the Scumblr initializer.'.freeze
+        return
+      end
+
+      build_results
+    end
+
+    private
+
+    def build_results
+      res = []
+      graph = Koala::Facebook::API.new(@access_token)
+      graph.search(@query, type: 'page'.freeze).map do |result|
+        sub_result = graph.get_connection result['id'].to_i, 'feed'.freeze, fields: %w(id created_time caption message)
+        next unless sub_result
+        res << manage_sub_result(sub_result)
+      end
+      res.flatten!
+    end
+
+    def manage_sub_result(sub_result)
+      res = []
+      sub_result.each do |sr|
+        caption = (sr['caption'] || '').force_encoding(Encoding::UTF_8).freeze
+        msg = (sr['message'] || '').force_encoding(Encoding::UTF_8).freeze
+        res << {
+            title: (msg.empty? ? caption : msg).truncate(128),
+            url: "https://www.facebook.com/#{sr['id'].to_s.gsub!(/_/, '/posts/')}",
+            domain: 'facebook.com'.freeze
         }
+      end
+      res
     end
-
-    search_results.map{|result| {title: (result[:message].empty? ? encode(result[:caption]) : encode(result[:message])).truncate(128),
-                   url: result[:post_id], domain: "facebook.com"}}
   end
-
-
-
-  private
-
-  def encode(string)
-    encoding_options = {
-      :invalid       => :replace,  # Replace invalid byte sequences
-      :undef       => :replace,  # Replace anything not defined in ASCII
-      :replace       => '',    # Use a blank for those replacements
-      :universal_newline => true     # Always break lines with \n
-    }
-
-    string.encode(Encoding.find("ASCII"), encoding_options)
-  end
-
 end


### PR DESCRIPTION
With this fix "Facebook Search" works with Koala 2.2.x.