### PR TITLE
support searching Github code, issues or users, not just repositories (which remains the default)

### DIFF
--- a/lib/search_providers/github.rb
+++ b/lib/search_providers/github.rb
@@ -34,7 +34,13 @@ class SearchProvider::Github < SearchProvider::Provider
   end
 
   def run
-    url = URI.escape('https://api.github.com/search/' + @options[:type].to_s + '?q=' + @query)
+    case @options[:type].to_s
+      when "repositories", "code", "issues", "users"
+        url = URI.escape('https://api.github.com/search/' + @options[:type].to_s + '?q=' + @query)
+      else
+        Rails.logger.error "Did not recognize this type of search. Please choose 'repositories', 'code', 'issues' or 'users'. Leave blank for the default (repositories)"
+        return []
+    end
     response = Net::HTTP.get_response(URI(url))
     results = []
     if response.code == "200"

--- a/lib/search_providers/github.rb
+++ b/lib/search_providers/github.rb
@@ -23,15 +23,18 @@ class SearchProvider::Github < SearchProvider::Provider
   end
 
   def self.options
-    {}
+    {
+      :type=>{name: "Search type ('repositories' (default), 'code', 'issues', 'users')", description: "Specifies which type of search to perform", required: false}
+    }
   end
 
   def initialize(query, options={})
     super
+    @options[:type] = @options[:type].blank? ? "repositories" : @options[:type]
   end
 
   def run
-    url = URI.escape('https://api.github.com/search/repositories?q=' + @query)
+    url = URI.escape('https://api.github.com/search/' + @options[:type].to_s + '?q=' + @query)
     response = Net::HTTP.get_response(URI(url))
     results = []
     if response.code == "200"


### PR DESCRIPTION
As per the request at https://github.com/Netflix/Scumblr/pull/40#issuecomment-155142446, this modifies the Github search provider to be capable of searching for 'users', 'issues', or 'code', not just 'repositories' (the default).

Note: I think this would *look* better as a combobox, but it seems Scumblr's hardcoded any Search Provider's options as a text field. Too much work for me to change this right now, so that's why the 'name' of the option is a bit longer than usual (to explain to the user what the valid options are).

Finally (can't think of a better place to say this), Github's 'code' search requires you to also specify a user, organization, or repository within which to do the code search. The Scumblr user will need to understand that the 'Query' has to be something like 'color+repo:jquery/jquery' as opposed to just 'color', in order to actually get any results.

In other words, it depends on some existing knowledge of the Github search API as defined at https://developer.github.com/v3/search/#search-code