### PR TITLE
Update libv8 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
     less-rails (2.5.0)
       actionpack (>= 3.1)
       less (~> 2.5.0)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.15)
     listen (2.7.9)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)


### PR DESCRIPTION
Currently, the libv8 version used (v3.16.14.3) has a pesky issue where it tries to build libv8 with the default upstream flag of (-Werror).

This causes the compiler to give up and exit when it encounters a warning.

```
Installing libv8 3.16.14.3 with native extensions

Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /Users/oogali/.rbenv/versions/2.0.0-p481/bin/ruby extconf.rb
creating Makefile
Compiling v8 for x64
Using python 2.7.10
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Using compiler: /usr/bin/g++
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                 ^
1 error generated.
make[1]: *** [/Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o] Error 1
make: *** [x64.release] Error 2
/Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/ext/libv8/location.rb:36:in `block in verify_installation!': libv8 did not install properly, expected binary v8 archive '/Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/tools/gyp/libv8_base.a'to exist, but it was not found (Libv8::Location::Vendor::ArchiveNotFound)
	from /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/ext/libv8/location.rb:35:in `each'
	from /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/ext/libv8/location.rb:35:in `verify_installation!'
	from /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/ext/libv8/location.rb:26:in `install!'
	from extconf.rb:7:in `<main>'
GYP_GENERATORS=make \
	build/gyp/gyp --generator-output="out" build/all.gyp \
	              -Ibuild/standalone.gypi --depth=. \
	              -Dv8_target_arch=x64 \
	              -S.x64  -Dv8_enable_backtrace=1 -Dv8_can_use_vfp2_instructions=true -Darm_fpu=vfpv2 -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3
  CXX(target) /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/allocation.o
  CXX(target) /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o
  CXX(target) /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o
  CXX(target) /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum-dtoa.o
  CXX(target) /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o


Gem files will remain installed in /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3 for inspection.
Results logged to /Users/oogali/.rbenv/versions/2.0.0-p481/lib/ruby/gems/2.0.0/gems/libv8-3.16.14.3/ext/libv8/gem_make.out
```

The libv8 gem developers have disabled this compiler option in version v3.16.14.15 (https://github.com/cowboyd/libv8/commit/fac6535f42d01cca865866c54b08383d19d99485).

This PR changes Scumblr to use said version.