### PR TITLE
Use environment variables to set HTTP endpoint

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,5 @@ silence_warnings do
   IRB = Pry
 end
 
-Rails.application.routes.default_url_options[:host] = "localhost:3000"
+Rails.application.routes.default_url_options[:host] = ENV['SCUMBLR_HTTP_HOST'] || 'localhost:3000'
+Rails.application.routes.default_url_options[:protocol] = ENV['SCUMBLR_HTTP_PROTO'] || 'http'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,5 +88,5 @@ Scumblr::Application.configure do
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
 end
 
-Rails.application.routes.default_url_options[:host] = "<PROD HOST>"
-Rails.application.routes.default_url_options[:protocol] = "https"
+Rails.application.routes.default_url_options[:host] = ENV['SCUMBLR_HTTP_HOST'] || 'scumblr'
+Rails.application.routes.default_url_options[:protocol] = ENV['SCUMBLR_HTTP_PROTO'] || 'https'


### PR DESCRIPTION
Currently, the code defaults to using values from the configuration file with no other way to override them.

These creates a challenge in turning this into a Docker container, so I've changed the configuration files to accept values via environment variables, and fall back to sensible defaults.

You can use `SCUMBLR_HTTP_HOST` and `SCUMBLR_HTTP_PROTO` to set the hostname and protocol (http or https) in either development or production environments.

If these parameters aren't provided, the effective configuration will fall back to `http://localhost:3000` and `https://scumblr` for development and production respectively.