### PR TITLE
Authentication errors

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -195,10 +195,10 @@ class Task < ActiveRecord::Base
     if(results.blank?)
       # puts Thread.current["current_events"]
       unless Thread.current["current_events"].nil?
-        task.metadata.merge!({"current_events": Thread.current["current_events"]})
+        task.metadata.merge!({"current_events" => Thread.current["current_events"]})
       end
       unless Thread.current["current_results"].nil?
-        task.metadata.merge!({"current_results": Thread.current["current_results"]})
+        task.metadata.merge!({"current_results" => Thread.current["current_results"]})
       end
       if was_successful
         task.metadata["_last_run"] = task.metadata["_last_successful_run"] = Time.now
@@ -248,10 +248,10 @@ class Task < ActiveRecord::Base
     results = nil
     # Sync up and merge all the results and events changed
     unless Thread.current["current_events"].nil?
-      task.metadata.merge!({"current_events": Thread.current["current_events"]})
+      task.metadata.merge!({"current_events" => Thread.current["current_events"]})
     end
     unless Thread.current["current_results"].nil?
-      task.metadata.merge!({"current_results": Thread.current["current_results"]})
+      task.metadata.merge!({"current_results" => Thread.current["current_results"]})
     end
     Thread.current["current_results"] = {}
     Thread.current["previous_results"] = {}


### PR DESCRIPTION
Following instructions from https://github.com/Netflix/Scumblr/wiki/Setting-up-Scumblr-2.0-(New-install)

Post-install, having created my first user, authentication returns with 500 errors.
```

Started GET "/" for 127.0.0.1 at 2017-02-12 11:34:47 -0500
Processing by ResultsController#index as HTML
Completed 401 Unauthorized in 0ms (ActiveRecord: 0.0ms)


Started GET "/" for 78.193.67.92 at 2017-02-12 11:34:48 -0500
Processing by ResultsController#index as HTML
  User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1  ORDER BY "users"."id" ASC LIMIT 1  [["id", 1]]
   (0.3ms)  SELECT COUNT(*) FROM "results"
   (0.2ms)  SELECT COUNT(*) FROM "statuses" WHERE "statuses"."closed" = $1  [["closed", "t"]]
  Result Load (0.3ms)  SELECT  DISTINCT results.id, results.title, results.url, results.status_id, results.created_at, results.updated_at, results.domain, results.user_id FROM "results"  ORDER BY "results"."created_at" DESC LIMIT 25 OFFSET 0
   (0.3ms)  SELECT DISTINCT COUNT(DISTINCT "results"."id") FROM "results"
  Rendered results/index_columns/_screenshot_header.html.erb (0.0ms)
  Rendered results/_results_table.html.erb (25.6ms)
  Status Load (0.2ms)  SELECT "statuses".* FROM "statuses"
  User Load (0.3ms)  SELECT "users".* FROM "users"
  Tag Load (0.2ms)  SELECT "tags".* FROM "tags"
  CACHE (0.0ms)  SELECT "users".* FROM "users"
  CACHE (0.0ms)  SELECT "statuses".* FROM "statuses"
  Rendered results/_search_fields.html.erb (24.0ms)
  Rendered results/index.html.erb within layouts/application (75.7ms)
Completed 500 Internal Server Error in 120ms (ActiveRecord: 2.2ms)

SyntaxError - /usr/src/scumblr/app/models/task.rb:198: syntax error, unexpected ':', expecting =>
...adata.merge!({"current_events": Thread.current["current_even...
...                               ^
/usr/src/scumblr/app/models/task.rb:198: syntax error, unexpected '}', expecting keyword_end
...read.current["current_events"]})
...                               ^
/usr/src/scumblr/app/models/task.rb:201: syntax error, unexpected ':', expecting =>
...data.merge!({"current_results": Thread.current["current_resu...
...                               ^
/usr/src/scumblr/app/models/task.rb:201: syntax error, unexpected '}', expecting keyword_end
...ead.current["current_results"]})
...                               ^
/usr/src/scumblr/app/models/task.rb:251: syntax error, unexpected ':', expecting =>
...adata.merge!({"current_events": Thread.current["current_even...
...                               ^
/usr/src/scumblr/app/models/task.rb:251: syntax error, unexpected '}', expecting keyword_end
...read.current["current_events"]})
...                               ^
/usr/src/scumblr/app/models/task.rb:254: syntax error, unexpected ':', expecting =>
...data.merge!({"current_results": Thread.current["current_resu...
...                               ^
/usr/src/scumblr/app/models/task.rb:254: syntax error, unexpected '}', expecting keyword_end
...ead.current["current_results"]})
...                               ^
/usr/src/scumblr/app/models/task.rb:267: syntax error, unexpected end-of-input, expecting keyword_end:
  app/models/task.rb:198:in `'
  activesupport (4.2.6) lib/active_support/dependencies.rb:457:in `block in load_file'
  activesupport (4.2.6) lib/active_support/dependencies.rb:647:in `new_constants_in'
  activesupport (4.2.6) lib/active_support/dependencies.rb:456:in `load_file'
  activesupport (4.2.6) lib/active_support/dependencies.rb:354:in `require_or_load'
  activesupport (4.2.6) lib/active_support/dependencies.rb:494:in `load_missing_constant'
  activesupport (4.2.6) lib/active_support/dependencies.rb:184:in `const_missing'
  activesupport (4.2.6) lib/active_support/dependencies.rb:526:in `load_missing_constant'
  activesupport (4.2.6) lib/active_support/dependencies.rb:184:in `const_missing'
  activesupport (4.2.6) lib/active_support/dependencies.rb:526:in `load_missing_constant'
  activesupport (4.2.6) lib/active_support/dependencies.rb:184:in `const_missing'
  app/views/results/_search_fields.html.erb:23:in `block in _app_views_results__search_fields_html_erb__286786669149282137_65760200'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `block in capture'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:202:in `with_output_buffer'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `capture'
  actionview (4.2.6) lib/action_view/helpers/tag_helper.rb:106:in `content_tag'
  actionview (4.2.6) lib/action_view/helpers/form_tag_helper.rb:214:in `label_tag'
  app/views/results/_search_fields.html.erb:22:in `_app_views_results__search_fields_html_erb__286786669149282137_65760200'
  actionview (4.2.6) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.6) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.6) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.6) lib/action_view/template.rb:143:in `render'
  actionview (4.2.6) lib/action_view/renderer/partial_renderer.rb:339:in `render_partial'
  actionview (4.2.6) lib/action_view/renderer/partial_renderer.rb:310:in `block in render'
  actionview (4.2.6) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.6) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.6) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.6) lib/action_view/renderer/partial_renderer.rb:309:in `render'
  actionview (4.2.6) lib/action_view/renderer/renderer.rb:51:in `render_partial'
  actionview (4.2.6) lib/action_view/renderer/renderer.rb:25:in `render'
  actionview (4.2.6) lib/action_view/helpers/rendering_helper.rb:32:in `render'
  app/views/results/index.html.erb:154:in `block (2 levels) in _app_views_results_index_html_erb__2078739084642581685_27079420'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `block in capture'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:202:in `with_output_buffer'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `capture'
  actionview (4.2.6) lib/action_view/helpers/form_helper.rb:444:in `form_for'
  ransack (1.7.0) lib/ransack/helpers/form_helper.rb:34:in `search_form_for'
  app/views/results/index.html.erb:153:in `block in _app_views_results_index_html_erb__2078739084642581685_27079420'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `block in capture'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:202:in `with_output_buffer'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:38:in `capture'
  actionview (4.2.6) lib/action_view/helpers/capture_helper.rb:152:in `content_for'
  app/views/results/index.html.erb:144:in `_app_views_results_index_html_erb__2078739084642581685_27079420'
  actionview (4.2.6) lib/action_view/template.rb:145:in `block in render'
  activesupport (4.2.6) lib/active_support/notifications.rb:166:in `instrument'
  actionview (4.2.6) lib/action_view/template.rb:333:in `instrument'
  actionview (4.2.6) lib/action_view/template.rb:143:in `render'
  actionview (4.2.6) lib/action_view/renderer/template_renderer.rb:54:in `block (2 levels) in render_template'
  actionview (4.2.6) lib/action_view/renderer/abstract_renderer.rb:39:in `block in instrument'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.6) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `instrument'
  actionview (4.2.6) lib/action_view/renderer/abstract_renderer.rb:39:in `instrument'
  actionview (4.2.6) lib/action_view/renderer/template_renderer.rb:53:in `block in render_template'
  actionview (4.2.6) lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
  actionview (4.2.6) lib/action_view/renderer/template_renderer.rb:52:in `render_template'
  actionview (4.2.6) lib/action_view/renderer/template_renderer.rb:14:in `render'
  actionview (4.2.6) lib/action_view/renderer/renderer.rb:46:in `render_template'
  actionview (4.2.6) lib/action_view/renderer/renderer.rb:27:in `render'
  actionview (4.2.6) lib/action_view/rendering.rb:100:in `_render_template'
  actionpack (4.2.6) lib/action_controller/metal/streaming.rb:217:in `_render_template'
  actionview (4.2.6) lib/action_view/rendering.rb:83:in `render_to_body'
  actionpack (4.2.6) lib/action_controller/metal/rendering.rb:32:in `render_to_body'
  actionpack (4.2.6) lib/action_controller/metal/renderers.rb:37:in `render_to_body'
  actionpack (4.2.6) lib/abstract_controller/rendering.rb:25:in `render'
  actionpack (4.2.6) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
  activesupport (4.2.6) lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
  /usr/lib/ruby/2.1.0/benchmark.rb:294:in `realtime'
  activesupport (4.2.6) lib/active_support/core_ext/benchmark.rb:12:in `ms'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:44:in `block in render'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
  activerecord (4.2.6) lib/active_record/railties/controller_runtime.rb:25:in `cleanup_view_runtime'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:43:in `render'
  actionpack (4.2.6) lib/action_controller/metal/mime_responds.rb:217:in `respond_to'
  app/controllers/results_controller.rb:136:in `index'
  actionpack (4.2.6) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  actionpack (4.2.6) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.6) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.6) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.6) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.6) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
  activesupport (4.2.6) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.6) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
  activesupport (4.2.6) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  activesupport (4.2.6) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.6) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (4.2.6) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.6) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.6) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (4.2.6) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  actionpack (4.2.6) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
  activerecord (4.2.6) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (4.2.6) lib/abstract_controller/base.rb:137:in `process'
  actionview (4.2.6) lib/action_view/rendering.rb:30:in `process'
  actionpack (4.2.6) lib/action_controller/metal.rb:196:in `dispatch'
  actionpack (4.2.6) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.6) lib/action_controller/metal.rb:237:in `block in action'
  actionpack (4.2.6) lib/action_dispatch/routing/route_set.rb:74:in `dispatch'
  actionpack (4.2.6) lib/action_dispatch/routing/route_set.rb:43:in `serve'
  actionpack (4.2.6) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.6) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.6) lib/action_dispatch/routing/route_set.rb:817:in `call'
  bullet (5.1.0) lib/bullet/rack.rb:10:in `call'
  meta_request (0.3.4) lib/meta_request/middlewares/app_request_handler.rb:13:in `call'
  meta_request (0.3.4) lib/meta_request/middlewares/meta_request_handler.rb:13:in `call'
  warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.6) lib/warden/manager.rb:34:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/flash.rb:260:in `call'
  rack (1.6.4) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.4) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.2.6) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.2.6) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.6) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.6) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.6) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.6) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  rack-contrib (1.1.0) lib/rack/contrib/response_headers.rb:17:in `call'
  meta_request (0.3.4) lib/meta_request/middlewares/headers.rb:16:in `call'
  better_errors (1.1.0) lib/better_errors/middleware.rb:84:in `protected_app_call'
  better_errors (1.1.0) lib/better_errors/middleware.rb:79:in `better_errors_call'
  better_errors (1.1.0) lib/better_errors/middleware.rb:56:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.2.6) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.6) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.6) lib/rails/rack/logger.rb:20:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.6.4) lib/rack/methodoverride.rb:22:in `call'
  rack (1.6.4) lib/rack/runtime.rb:18:in `call'
  activesupport (4.2.6) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  rack (1.6.4) lib/rack/lock.rb:17:in `call'
  actionpack (4.2.6) lib/action_dispatch/middleware/static.rb:120:in `call'
  rack (1.6.4) lib/rack/sendfile.rb:113:in `call'
  railties (4.2.6) lib/rails/engine.rb:518:in `call'
  railties (4.2.6) lib/rails/application.rb:165:in `call'
  rack (1.6.4) lib/rack/content_length.rb:15:in `call'
  unicorn (4.8.3) lib/unicorn/http_server.rb:576:in `process_client'
  unicorn (4.8.3) lib/unicorn/http_server.rb:670:in `worker_loop'
  unicorn (4.8.3) lib/unicorn/http_server.rb:525:in `spawn_missing_workers'
  unicorn (4.8.3) lib/unicorn/http_server.rb:140:in `start'
  unicorn-rails (2.1.1) lib/unicorn_rails.rb:26:in `run'
  rack (1.6.4) lib/rack/server.rb:286:in `start'
  railties (4.2.6) lib/rails/commands/server.rb:80:in `start'
  railties (4.2.6) lib/rails/commands/commands_tasks.rb:80:in `block in server'
  railties (4.2.6) lib/rails/commands/commands_tasks.rb:75:in `server'
  railties (4.2.6) lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  railties (4.2.6) lib/rails/commands.rb:17:in `<top (required)>'
  bin/rails:4:in `<main>'

^C
```

This patch fixes, somehow.
Full disclosure: I'm no ruby developer, I have no idea what I just did, ... I may be wrong. Then again, now I can login.