### PR TITLE
Set clone URL during GitHub sync task

### DIFF
--- a/lib/scumblr_tasks/sync_tasks/github_sync.rb
+++ b/lib/scumblr_tasks/sync_tasks/github_sync.rb
@@ -177,6 +177,13 @@ class ScumblrTask::GithubSyncAnalyzer < ScumblrTask::Base
         res.metadata["github_analyzer"]["language"] = repo["language"]
         res.metadata["github_analyzer"]["private"] = repo["private"]
         res.metadata["github_analyzer"]["account_type"] = repo.owner.type
+
+        if repo.private
+          res.metadata["github_analyzer"]["git_clone_url"] = repo["ssh_url"]
+        else
+          res.metadata["github_analyzer"]["git_clone_url"] = repo["clone_url"]
+	end
+
         res.save
       end
     end


### PR DESCRIPTION
Does this make sense? Or are you supposed to always use a GitHub analyzer task to get the URL?

(This change should probably also be applied to the GitHub analyzer task instead of assembling an SSH URI by hand.)