### PR TITLE
Use Brakeman fingerprints for vulnerability deduplication

### DIFF
--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -15,7 +15,8 @@ class Vulnerability
     :score, :file_path, :file_name, :task_name, :task_id,
     :key_suffix, :code_fragment, :match_location, :before,
     :after, :line_number, :status_code, :path,
-    :reporter, :reward, :jira_ids, :payload, :app, :negative
+    :reporter, :reward, :jira_ids, :payload, :app, :negative,
+    :fingerprint
 
   def initialize
     @attack_vectors=[]
@@ -187,6 +188,8 @@ Result.class_eval do
         r["reporter"] = v.reporter if v.reporter
         r["reward"] = v.reward if v.reward
 
+        r["fingerprint"] = v.fingerprint if v.fingerprint
+
         # Do not want to overwrite existing details
         # r["details"] = v.details
 
@@ -333,15 +336,30 @@ Result.class_eval do
       existing_vulnerabilities = self.metadata["vulnerabilities"]
     end
 
-    # This is a static analyzer match for content
-    if vulnerability.match_location == "content"
+    case vulnerability.match_location
+    when "content"
+      # This is a static analyzer match for content
       existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["code_fragment"] == vulnerability.code_fragment && v["term"] == vulnerability.term }
+    when "path"
       # This is a static analyzer match for paths
-    elsif vulnerability.match_location == "path"
       existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["term"] == vulnerability.term}
+    when "headers"
       # This matches curl analyzers running on headers
-    elsif vulnerability.match_location == "headers"
       existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["term"] == vulnerability.term}
+    when "fingerprint"
+      # This is the Rails analyzer fingerprint matcher with fallback
+      existing_vulnerabilities.select do |v|
+        if v["url"] != vulnerability.url
+          false
+        elsif v["fingerprint"] && v["fingerprint"] == vulnerability.fingerprint
+          true
+        else
+          # Fall back on heuristics until fingerprint updated
+          ["severity", "type", "source_code_file", "source_code_line"].all? do |data|
+            v[data] == vulnerability.send(data.to_sym)
+          end
+        end
+      end
     else
       existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["type"] == vulnerability.type}
     end

--- a/lib/scumblr_tasks/security/rails_analyzer.rb
+++ b/lib/scumblr_tasks/security/rails_analyzer.rb
@@ -251,7 +251,9 @@ class ScumblrTask::RailsAnalyzer < ScumblrTask::Async
 
               if confidence_levels.include?(warning["confidence"].to_s.strip)
                 vuln = Vulnerability.new
+                vuln.match_location = "fingerprint"
                 vuln.type = warning["warning_type"].to_s
+                vuln.fingerprint = warning["fingerprint"]
                 vuln.source_code_file = warning["file"].to_s
                 vuln.source_code_line = warning["line"].to_s
                 vuln.source_code = get_relevant_source(scan_result["railspath"] + "/" + warning["file"].to_s, warning["line"].to_i)


### PR DESCRIPTION
This change stores and uses the warning fingerprints provided by Brakeman for deduplication. This is a little more reliable than the current method.

For existing warnings, it falls back on comparing type, severity, file, and line number. For duplicates, it adds the fingerprint after matching.