### PR TITLE
Deleted call to #skip as it was removed in Rails 4

### DIFF
--- a/test/models/results_test.rb
+++ b/test/models/results_test.rb
@@ -147,8 +147,6 @@ class ResultTest < ActiveSupport::TestCase
       assert_equal(Fixnum, fixture_result.metadata["sketchy_ids"].first.class)
       fixture_result.metadata["sketchy_ids"] = nil
     end
-  else
-    skip("no sketchy_url configured...skiping test.")
   end
 
   if Rails.configuration.try(:sketchy_url).present?
@@ -161,8 +159,6 @@ class ResultTest < ActiveSupport::TestCase
       foo = fixture_result.create_attachment_from_sketchy("https://www.google.com/")
       assert_equal(nil, fixture_result.metadata["sketchy_ids"])
     end
-  else
-    skip("no sketchy_url configured...skiping test.")
   end
 
 end


### PR DESCRIPTION
I was running tests locally without Sketchy configured. It looks like #skip was removed from AR in Rails 4, so I removed the method as Scumblr is currently pegged at 4.2.6.

https://github.com/rails/rails/commit/fc57003feb1af98f9b4470c362e05755ce10b618#diff-f44e5c73c8640105ff6fd71298a18302
