### PR TITLE
Prevent tabnapping on outbound links

### DIFF
--- a/app/views/results/index_columns/_link_data.html.erb
+++ b/app/views/results/index_columns/_link_data.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "Link", result.url, data: {confirm: "Are you sure? This will take you to a potentially dangerous site!\n\nURL: " + result.url.to_s}, target:"_blank"  %>
+<%= link_to "Link", result.url, data: {confirm: "Are you sure? This will take you to a potentially dangerous site!\n\nURL: " + result.url.to_s}, target:"_blank" rel:"noopener noreferrer" %>


### PR DESCRIPTION
Small issue, but if we really don't trust outbound sites then we should null out the referrer. 
ref: https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/