### PR TITLE
Adds Vulnerability Cleaner Task

### DIFF
--- a/lib/scumblr_tasks/maintenance_tasks/vulnerability_cleaner.rb
+++ b/lib/scumblr_tasks/maintenance_tasks/vulnerability_cleaner.rb
@@ -1,0 +1,124 @@
+#     Copyright 2016 Netflix, Inc.
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+require 'posix/spawn'
+
+class ScumblrTask::VulnerabilityCleaner < ScumblrTask::AsyncSidekiq
+  include POSIX::Spawn
+  def self.task_type_name
+    "Vulnerability Cleaner"
+  end
+
+  def self.task_category
+    "Maintenance"
+  end
+
+  def self.worker_class
+    return ScumblrWorkers::VulnerabilityCleanerWorker
+  end
+
+  def self.options
+    return {
+      :saved_result_filter=> {name: "Result Filter",
+                              description: "Only run cleaner against matching filter",
+                              required: false,
+                              type: :saved_result_filter
+                              },
+      :task_id=> {name: "Remove based on Task id",
+                  description: "Removes all vulns associated with task_id",
+                  required: false,
+                  type: :string
+                  },
+      :vuln_value => {name: "Remove based on metadata value",
+                      description: "Traverse vulnerability metadata and delete all vulns who contain this value",
+                      required: false,
+                      type: :string
+                      }
+    }
+  end
+
+  def self.description
+    "Traverses result vulnerability metadata and deletes vulns based on search criteria"
+  end
+
+  def self.config_options
+    {
+    }
+  end
+
+  def initialize(options={})
+    super
+
+    unless @options[:task_id].present? or @options[:vuln_value].present?
+      raise ScumblrTask::TaskException.new("No search terms provided.")
+      return
+    end
+
+  end
+
+  def run
+    super
+  end
+
+end
+
+class ScumblrWorkers::VulnerabilityCleanerWorker < ScumblrWorkers::AsyncSidekiqWorker
+
+  def perform_work(result_id)
+    r = Result.find(result_id)
+
+    # Skip results which have no vulnerabilities
+    if r[:metadata].try(:[], "vulnerabilities").blank?
+      return nil
+    else
+      # Delete all vulns that match the task_id.
+      # This is more memory efficent since it doesn't have to
+      # recursively crawl the hash.
+      if @options[:task_id].present?
+        r[:metadata]["vulnerabilities"].delete_if do |vul|
+          if vul["task_id"] == @options[:task_id]
+            puts r.url
+            true
+          end
+        end
+        r.save if r.changed?
+      else
+        # Delete all vulns that match the specified value recrusively.
+        r[:metadata]["vulnerabilities"].delete_if do |vul|
+            if iterate(vul, @options[:vuln_value]) == "found"
+              puts r.url
+              true
+            end
+        end
+        r.save if r.changed?
+      end
+
+      return []
+    end
+  end
+
+  def iterate(h, term)
+    h.each do |k,v|
+      # If it's an array value will be k, otherwise value will be v
+      value = v || k
+
+      if value.is_a?(Hash) || value.is_a?(Array)
+        # Iterate again until we end up with a string
+        iterate(value, term)
+      elsif value == term
+        # Identified term, so we can mark for deletion
+        return "found"
+      end
+    end
+  end
+end

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -125,8 +125,8 @@ result_2:
       match_location: content
     - id: da05be901b9be3c6fadec856d5f29158
       url: https://github.com/Netflix/grouper/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
-      term: Api
-      type: '"Api" - content match'
+      term: Apis
+      type: '"Apis" - content match'
       score: 1.131043
       source:
       - github
@@ -153,3 +153,71 @@ result_2:
       key_suffix: {}
   metadata_hash:
 
+result_3:
+  id: 3
+  title: https://github.com/Netflix/grouper2
+  url: https://github.com/Netflix/grouper2
+  status_id:
+  created_at: 2016-11-16 01:45:41.206070000 Z
+  updated_at: 2017-01-12 21:36:06.803003000 Z
+  domain: github.com
+  user_id:
+  content:
+  metadata_archive: {}
+  metadata:
+    github_analyzer:
+      owner: Netflix
+      private: true
+      language:
+      account_type: Organization
+      git_clone_url: ssh://github.com/Netflix/grouper2.git
+    vulnerabilities:
+    - id: 2600a431554c04bbbcd2b74a57f18d54
+      url: https://github.com/Netflix/grouper2/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
+      term: Api
+      type: '"Api" - content match'
+      score: 1.131043
+      source:
+      - github
+      status: Open
+      task_id: '3'
+      severity: High
+      file_name: services.js
+      identified: '2016-11-15T17:45:41.211-08:00'
+      code_fragment: |-
+        'use strict';
+
+        angular.module('grouper')
+          .service('SearchApi', function (GrouperRestangular
+      external_link: {}
+      attack_vectors: []
+      match_location: content
+    - id: da05be901b9be3c6fadec856d5f29158
+      url: https://github.com/Netflix/grouper/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
+      term: Apis
+      type: '"Apis" - content match'
+      score: 1.131043
+      source:
+      - github
+      status: Open
+      task_id: '3'
+      severity: Observation
+      file_name: services.js
+      identified: '2016-11-15T17:45:41.211-08:00'
+      code_fragment: |-
+        ) {
+            return GrouperRestangular.all('search');
+          })
+          .service('SearchService', function (SearchApi
+      external_link: {}
+      attack_vectors: []
+      match_location: content
+    vulnerability_count:
+      open: 2
+      closed: 0
+      source:
+        github: 2
+      task_id:
+        '2': 2
+      key_suffix: {}
+  metadata_hash:

--- a/test/fixtures/saved_filters.yml
+++ b/test/fixtures/saved_filters.yml
@@ -68,3 +68,40 @@ saved_filter_49:
   saved_filter_type: Result
   store_index_columns: false
   index_columns: 'null'
+
+saved_filter_83:
+  id: 83
+  name: All Results
+  query: !ruby/hash-with-ivars:ActionController::Parameters
+    elements:
+      url_cont: ''
+      url_not_cont: ''
+      title_cont: ''
+      title_not_cont: ''
+      tags_id_in: &1
+      - ''
+      user_id_in:
+      - ''
+      status_id_in:
+      - ''
+      tasks_id_in:
+      - ''
+      id_in_saved_event_filter: ''
+      metadata_search: ''
+      flags_id_in:
+      - ''
+      stages_id_in:
+      - ''
+      status_id_includes_closed: '0'
+    ivars:
+      :@permitted: false
+      :@converted_arrays: !ruby/object:Set
+        hash:
+          *1: true
+  user_id: 2
+  public: false
+  created_at: 2017-08-04 17:12:20.750895000 Z
+  updated_at: 2017-08-04 17:12:20.750895000 Z
+  saved_filter_type: Result
+  store_index_columns: false
+  index_columns: 'null'

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -719,3 +719,77 @@ task_70:
     _last_status_event: 6684829
     _last_status_message: Task completed in 0.987644 seconds
     _last_successful_run: '2017-05-31T11:35:23.850-07:00'
+
+task_88:
+  id: 88
+  task_type: ScumblrTask::VulnerabilityCleaner
+  options: !ruby/hash-with-ivars:ActionController::Parameters
+    elements:
+      saved_result_filter: '83'
+      vuln_value: Api
+    ivars:
+      :@permitted: true
+      :@converted_arrays: !ruby/object:Set
+        hash:
+          ? - ''
+          : true
+  name: Cleaner
+  description: ''
+  created_at: 2017-08-04 16:19:30.145176000 Z
+  updated_at: 2017-08-04 19:27:11.838919000 Z
+  query: ''
+  enabled: true
+  group: 1
+  metadata:
+    _last_run: '2017-08-04T12:27:11.554-07:00'
+    _start_time: '2017-08-04T12:27:06.384-07:00'
+    _last_status: Success
+    current_events: {}
+    current_results: {}
+    previous_events:
+      Error: []
+      Warning: []
+    previous_results:
+      created: []
+      updated: []
+    _last_status_event: 6687341
+    _last_status_message: Task completed in 4.512189 seconds
+    _last_successful_run: '2017-08-04T12:27:11.554-07:00'
+  run_type: scheduled
+
+task_89:
+  id: 89
+  task_type: ScumblrTask::VulnerabilityCleaner
+  options: !ruby/hash-with-ivars:ActionController::Parameters
+    elements:
+      saved_result_filter: '83'
+      task_id: '2'
+    ivars:
+      :@permitted: true
+      :@converted_arrays: !ruby/object:Set
+        hash:
+          ? - ''
+          : true
+  name: Cleaner
+  description: ''
+  created_at: 2017-08-04 16:19:30.145176000 Z
+  updated_at: 2017-08-04 19:37:52.769812000 Z
+  query: ''
+  enabled: true
+  group: 1
+  metadata:
+    _last_run: '2017-08-04T12:27:11.554-07:00'
+    _start_time: '2017-08-04T12:27:06.384-07:00'
+    _last_status: Success
+    current_events: {}
+    current_results: {}
+    previous_events:
+      Error: []
+      Warning: []
+    previous_results:
+      created: []
+      updated: []
+    _last_status_event: 6687341
+    _last_status_message: Task completed in 4.512189 seconds
+    _last_successful_run: '2017-08-04T12:27:11.554-07:00'
+  run_type: scheduled

--- a/test/models/results_test.rb
+++ b/test/models/results_test.rb
@@ -38,7 +38,7 @@ class ResultTest < ActiveSupport::TestCase
   test "should perform a default result search" do
 
     ransack, results = Result.perform_search(q={"status_id_includes_closed"=>"0", "g"=>{"0"=>{"m"=>"or", "status_id_null"=>1, "status_closed_not_eq"=>true}}})
-    assert_equal(3, results.length)
+    assert_equal(4, results.length)
   end
 
   test "should perform a tag result search" do
@@ -68,7 +68,7 @@ class ResultTest < ActiveSupport::TestCase
 
   test "should perform a negative metadata  element result search" do
     ransack, results = Result.perform_search({metadata_search: "github_analyzer:private!=false"}, 1, 25, {include_metadata_column:true})
-    assert_equal(1, results.length)
+    assert_equal(2, results.length)
   end
 
   # Instance Method Tests

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -27,7 +27,7 @@ class StatusTest < ActiveSupport::TestCase
     # require 'active_record/fixtures'
     # ActiveRecord::FixtureSet.create_fixtures(Rails.root.join('test', 'fixtures'), 'results')
     # byebug
-    assert_equal(3, fixture_status.reset_default.count)
+    assert_equal(4, fixture_status.reset_default.count)
   end
 
   test "should to_string a name" do

--- a/test/tasks/vulnerability_cleaner_test.rb
+++ b/test/tasks/vulnerability_cleaner_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+class VulnerabilityCleanerTest < ActiveSupport::TestCase
+  test "execute confirm it removes vulns based on task id" do
+    result = Result.where(id: 2).first
+    task = Task.where(id: 89).first
+
+    assert_equal(2, result.metadata["vulnerabilities"].count)
+
+    task.perform_task
+    result = Result.where(id: 2).first
+
+    assert_equal(0, result.metadata["vulnerabilities"].count)
+  end
+  test "execute confirm it removes vulns based on value" do
+    result = Result.where(id: 3).first
+    task = Task.where(id: 88).first
+
+    assert_equal(2, result.metadata["vulnerabilities"].count)
+
+    task.perform_task
+    result = Result.where(id: 3).first
+
+    assert_equal(1, result.metadata["vulnerabilities"].count)
+  end
+end


### PR DESCRIPTION
@coffeetocode and I have been discussing that when we sometimes test or tryout tasks it would be nice to be able to roll back vulnerabilities created by a specific task.  This is especially useful if you realize you maybe added a term to an analyzer which generates too many false positives.  

The vulnerability cleaner task is a maintenance task that accepts one of two options.  You can specify a `task_id` and it will remove all vulnerabilities from results created by that task_id.  The second option is to specify a `vuln_value` which can be any arbitrary value found nested within a vulnerability object.  The code recursively traverses any elements inside the vuln object and breaks/deletes the vuln once it matches on the term.  You have to specify a saved_result_filter when running this analyzer.  

Tests are included for this task.  Additional test files and fixtures were updated do support the new tests.   