### PR TITLE
Bugfix/vuln helper

### DIFF
--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -206,12 +206,12 @@ Result.class_eval do
             r["reopened"] = Time.now
 
 
-          # elsif(r["status"] == "False Positive" && (Time.now - Time.parse(r["identified"])) > 30.days)
-          #   # Reopen False Positives that are re-identified more than 30 days later
-          #   # TODO: Make this logic configurable
-          #   vulnerability_status["reopened"] += 1
-          #   r["status"] = "Reopened"
-          #   r["identified"] = Time.now
+            # elsif(r["status"] == "False Positive" && (Time.now - Time.parse(r["identified"])) > 30.days)
+            #   # Reopen False Positives that are re-identified more than 30 days later
+            #   # TODO: Make this logic configurable
+            #   vulnerability_status["reopened"] += 1
+            #   r["status"] = "Reopened"
+            #   r["identified"] = Time.now
           else
             vulnerability_status["existing"] += 1
           end
@@ -446,7 +446,15 @@ Result.class_eval do
         end
       end
     else
-      existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["type"] == vulnerability.type}
+      begin
+        vuln_url = URI.parse(vulnerability.url)
+        existing_vulnerabilities.select{|v|  v["type"] == vulnerability.type && vuln_url.host == URI.parse(v["url"]).host && vuln_url.path == URI.parse(v["url"]).path && URI.parse(v["url"]).query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort == vuln_url.query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort}
+      rescue => e
+        require 'byebug'
+        byebug
+        puts 1
+      end
+
     end
   end
 

--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -447,14 +447,22 @@ Result.class_eval do
       end
     else
       begin
+
         vuln_url = URI.parse(vulnerability.url)
-        existing_vulnerabilities.select{|v|
-          v["type"] == vulnerability.type &&
-          vuln_url.host == URI.parse(v["url"]).host &&
-          vuln_url.path == URI.parse(v["url"]).path &&
-          URI.parse(v["url"]).query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort == vuln_url.query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort}
+        if vuln_url.query.to_s.present?
+          existing_vulnerabilities.select{|v|
+            v["type"] == vulnerability.type &&
+            vuln_url.host == URI.parse(v["url"]).host &&
+            vuln_url.path == URI.parse(v["url"]).path &&
+            URI.parse(v["url"]).query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort == vuln_url.query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort}
+          else
+            existing_vulnerabilities.select{|v|
+            v["type"] == vulnerability.type && v["url"] == vulnerability.url}
+          end
       rescue => e
-        puts e
+        require 'byebug'
+        byebug
+        puts 1
       end
 
     end

--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -448,11 +448,13 @@ Result.class_eval do
     else
       begin
         vuln_url = URI.parse(vulnerability.url)
-        existing_vulnerabilities.select{|v|  v["type"] == vulnerability.type && vuln_url.host == URI.parse(v["url"]).host && vuln_url.path == URI.parse(v["url"]).path && URI.parse(v["url"]).query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort == vuln_url.query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort}
+        existing_vulnerabilities.select{|v|
+          v["type"] == vulnerability.type &&
+          vuln_url.host == URI.parse(v["url"]).host &&
+          vuln_url.path == URI.parse(v["url"]).path &&
+          URI.parse(v["url"]).query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort == vuln_url.query.split('&').each_slice(1).map(&:join).map { |param| param.split('=').first }.sort}
       rescue => e
-        require 'byebug'
-        byebug
-        puts 1
+        puts e
       end
 
     end

--- a/lib/scumblr_tasks/maintenance_tasks/vulnerability_cleaner.rb
+++ b/lib/scumblr_tasks/maintenance_tasks/vulnerability_cleaner.rb
@@ -92,6 +92,7 @@ class ScumblrWorkers::VulnerabilityCleanerWorker < ScumblrWorkers::AsyncSidekiqW
             true
           end
         end
+        r.update_vulnerability_counts
         r.save if r.changed?
       else
         # Delete all vulns that match the specified value recrusively.
@@ -101,6 +102,7 @@ class ScumblrWorkers::VulnerabilityCleanerWorker < ScumblrWorkers::AsyncSidekiqW
               true
             end
         end
+        r.update_vulnerability_counts
         r.save if r.changed?
       end
 

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -192,6 +192,12 @@ result_3:
       external_link: {}
       attack_vectors: []
       match_location: content
+    - id: 2600a431554c04bbbcd2b74a57f18d54
+      url: https://www.netflix.com/bar/whatever?stuff=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>
+      type: 'Reflected XSS'
+      source:
+      - detectify
+      status: Open
     - id: da05be901b9be3c6fadec856d5f29158
       url: https://github.com/Netflix/grouper/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
       term: Apis
@@ -213,19 +219,19 @@ result_3:
       attack_vectors: []
       match_location: content
     vulnerability_count:
-      open: 2
+      open: 3
       closed: 0
       source:
-        github: 2
+        github: 3
       task_id:
-        '2': 2
+        '2': 3
       key_suffix: {}
   metadata_hash:
 
 result_277490:
   id: 277490
-  title: https://www.altoromutual.com
-  url: https://www.altoromutual.com
+  title: https://altoromutual.com
+  url: https://altoromutual.com
   status_id: 1
   created_at: 2017-08-14 20:35:41.923202000 Z
   updated_at: 2017-08-14 20:35:41.923202000 Z

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -198,6 +198,7 @@ result_3:
       task_id: '3'
       source:
       - detectify
+      severity: Observation
       status: Open
     - id: da05be901b9be3c6fadec856d5f29158
       url: https://github.com/Netflix/grouper/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -153,6 +153,83 @@ result_2:
       key_suffix: {}
   metadata_hash:
 
+result_4:
+  id: 4
+  title: https://github.com/Netflix/grouper3
+  url: https://github.com/Netflix/grouper3
+  status_id:
+  created_at: 2016-11-16 01:45:41.206070000 Z
+  updated_at: 2017-01-12 21:36:06.803003000 Z
+  domain: github.com
+  user_id:
+  content:
+  metadata_archive: {}
+  metadata:
+    github_analyzer:
+      owner: Netflix
+      private: true
+      language:
+      account_type: Organization
+      git_clone_url: ssh://github.com/Netflix/grouper3.git
+    vulnerabilities:
+    - id: 2600a431554c04bbbcd2b74a57f18d54
+      url: https://github.com/Netflix/grouper3/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
+      term: ssss
+      type: '"sss" - content match'
+      score: 1.131043
+      source:
+      - github
+      status: Open
+      task_id: '3'
+      severity: High
+      file_name: services.js
+      identified: '2016-11-15T17:45:41.211-08:00'
+      code_fragment: |-
+        'use strict';
+
+        angular.module('grouper')
+          .service('SearchApi', function (GrouperRestangular
+      external_link: {}
+      attack_vectors: []
+      match_location: content
+    - id: 22222431554c04bbbcd2b74a57f18d22
+      url: https://www.netflix.com/bar/whatever?stuff=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>
+      type: 'Reflected XSS'
+      task_id: '3'
+      source:
+      - detectify
+      severity: Observation
+      status: Open
+    - id: da05be901b9be3c6fadec856d5f29158
+      url: https://github.com/Netflix/grouper/blob/e4ff5ffe59451067881faeb08a46119c759e38b2/grouper/static/app/angular/search/services.js
+      term: sss
+      type: '"ssss" - content match'
+      score: 1.131043
+      source:
+      - github
+      status: Open
+      task_id: '3'
+      severity: Observation
+      file_name: services.js
+      identified: '2016-11-15T17:45:41.211-08:00'
+      code_fragment: |-
+        ) {
+            return GrouperRestangular.all('search');
+          })
+          .service('SearchService', function (SearchApi
+      external_link: {}
+      attack_vectors: []
+      match_location: content
+    vulnerability_count:
+      open: 3
+      closed: 0
+      source:
+        github: 3
+      task_id:
+        '2': 3
+      key_suffix: {}
+  metadata_hash:
+
 result_3:
   id: 3
   title: https://github.com/Netflix/grouper2
@@ -192,7 +269,7 @@ result_3:
       external_link: {}
       attack_vectors: []
       match_location: content
-    - id: 2600a431554c04bbbcd2b74a57f18d54
+    - id: 22222431554c04bbbcd2b74a57f18d22
       url: https://www.netflix.com/bar/whatever?stuff=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>
       type: 'Reflected XSS'
       task_id: '3'

--- a/test/fixtures/results.yml
+++ b/test/fixtures/results.yml
@@ -195,6 +195,7 @@ result_3:
     - id: 2600a431554c04bbbcd2b74a57f18d54
       url: https://www.netflix.com/bar/whatever?stuff=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>
       type: 'Reflected XSS'
+      task_id: '3'
       source:
       - detectify
       status: Open

--- a/test/models/results_test.rb
+++ b/test/models/results_test.rb
@@ -38,7 +38,7 @@ class ResultTest < ActiveSupport::TestCase
   test "should perform a default result search" do
 
     ransack, results = Result.perform_search(q={"status_id_includes_closed"=>"0", "g"=>{"0"=>{"m"=>"or", "status_id_null"=>1, "status_closed_not_eq"=>true}}})
-    assert_equal(5, results.length)
+    assert_equal(6, results.length)
   end
 
   test "should perform a tag result search" do
@@ -68,7 +68,7 @@ class ResultTest < ActiveSupport::TestCase
 
   test "should perform a negative metadata  element result search" do
     ransack, results = Result.perform_search({metadata_search: "github_analyzer:private!=false"}, 1, 25, {include_metadata_column:true})
-    assert_equal(2, results.length)
+    assert_equal(3, results.length)
   end
 
   # Instance Method Tests

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -27,7 +27,7 @@ class StatusTest < ActiveSupport::TestCase
     # require 'active_record/fixtures'
     # ActiveRecord::FixtureSet.create_fixtures(Rails.root.join('test', 'fixtures'), 'results')
     # byebug
-    assert_equal(5, fixture_status.reset_default.count)
+    assert_equal(6, fixture_status.reset_default.count)
   end
 
   test "should to_string a name" do

--- a/test/tasks/vulnerability_cleaner_test.rb
+++ b/test/tasks/vulnerability_cleaner_test.rb
@@ -16,7 +16,7 @@ class VulnerabilityCleanerTest < ActiveSupport::TestCase
     result = Result.where(id: 3).first
     task = Task.where(id: 88).first
 
-    assert_equal(2, result.metadata["vulnerabilities"].count)
+    assert_equal(3, result.metadata["vulnerabilities"].count)
 
     task.perform_task
     result = Result.where(id: 3).first

--- a/test/tasks/vulnerability_cleaner_test.rb
+++ b/test/tasks/vulnerability_cleaner_test.rb
@@ -21,8 +21,8 @@ class VulnerabilityCleanerTest < ActiveSupport::TestCase
     task.perform_task
     result = Result.where(id: 3).first
 
-    assert_equal(1, result.metadata["vulnerabilities"].count)
-    assert_equal(1, result.metadata["vulnerability_count"]["state"]["open"])
+    assert_equal(2, result.metadata["vulnerabilities"].count)
+    assert_equal(2, result.metadata["vulnerability_count"]["state"]["open"])
   end
   # Add test for counter object
   #

--- a/test/tasks/vulnerability_helper_test.rb
+++ b/test/tasks/vulnerability_helper_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+class VulnerabilityHelperTest < ActiveSupport::TestCase
+  test "Check for duplicate vulnerabilities which have complex query, should pass" do
+    require_relative "#{Rails.root.join('lib', 'helpers', 'vulnerability_helpers')}"
+    # The params and values are in a differnet order, but this should still result in a duplicate
+    result = Result.find(3)
+    vuln = Vulnerability.new
+    vuln.url = "https://www.netflix.com/bar/whatever?things=salsjklfasj&bar=<scrssfipt>alert()</script>&stuff=salkfsaafsafdskjfs"
+    vuln.type = "Reflected XSS"
+    result.update_vulnerabilities([vuln])
+
+    # With a differenet param, it should create a new result
+    assert_equal(3, result.metadata["vulnerabilities"].count)
+    vuln = Vulnerability.new
+    vuln.url = "https://www.netflix.com/bar/whatever?new_param=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>"
+    vuln.type = "Reflected XSS"
+    result.update_vulnerabilities([vuln])
+    assert_equal(4, result.metadata["vulnerabilities"].count)
+  end
+end

--- a/test/tasks/vulnerability_helper_test.rb
+++ b/test/tasks/vulnerability_helper_test.rb
@@ -4,6 +4,7 @@ class VulnerabilityHelperTest < ActiveSupport::TestCase
     require_relative "#{Rails.root.join('lib', 'helpers', 'vulnerability_helpers')}"
     # The params and values are in a differnet order, but this should still result in a duplicate
     result = Result.find(3)
+
     vuln = Vulnerability.new
     vuln.url = "https://www.netflix.com/bar/whatever?things=salsjklfasj&bar=<scrssfipt>alert()</script>&stuff=salkfsaafsafdskjfs"
     vuln.type = "Reflected XSS"
@@ -11,10 +12,10 @@ class VulnerabilityHelperTest < ActiveSupport::TestCase
 
     # With a differenet param, it should create a new result
     assert_equal(3, result.metadata["vulnerabilities"].count)
-    vuln = Vulnerability.new
-    vuln.url = "https://www.netflix.com/bar/whatever?new_param=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>"
-    vuln.type = "Reflected XSS"
-    result.update_vulnerabilities([vuln])
+    vuln2 = Vulnerability.new
+    vuln2.url = "https://www.netflix.com/bar/whatever?new_param=salkafdskjfs&things=salsjklfasj&bar=<script>alert()</script>"
+    vuln2.type = "Reflected XSS"
+    result.update_vulnerabilities([vuln2])
     assert_equal(4, result.metadata["vulnerabilities"].count)
   end
 end

--- a/test/tasks/vulnerability_helper_test.rb
+++ b/test/tasks/vulnerability_helper_test.rb
@@ -3,7 +3,7 @@ class VulnerabilityHelperTest < ActiveSupport::TestCase
   test "Check for duplicate vulnerabilities which have complex query, should pass" do
     require_relative "#{Rails.root.join('lib', 'helpers', 'vulnerability_helpers')}"
     # The params and values are in a differnet order, but this should still result in a duplicate
-    result = Result.find(3)
+    result = Result.find(4)
 
     vuln = Vulnerability.new
     vuln.url = "https://www.netflix.com/bar/whatever?things=salsjklfasj&bar=<scrssfipt>alert()</script>&stuff=salkfsaafsafdskjfs"

--- a/test/tasks/vulnerability_helper_test.rb
+++ b/test/tasks/vulnerability_helper_test.rb
@@ -18,3 +18,8 @@ class VulnerabilityHelperTest < ActiveSupport::TestCase
     assert_equal(4, result.metadata["vulnerabilities"].count)
   end
 end
+
+
+# detectify
+
+# we shoudl expec ton-call to be a bit busy


### PR DESCRIPTION
When two urls are identified that have different parameter values, Scumblr creates a new vulnerability instead of deduplicating.  This is because the old comparison just looked at an exact match of the URLs.  This PR parses the URL and plucks out every query parameter.  Regardless of parameter order or parameter values, it will deduplicate if all params, path, domain match.  

Tests were added to assert this works correctly.  This should help dedupliate vulns from scan engines that use nonces in parameter values.  