### PR TITLE
Feature/static analyzer auto remediate

### DIFF
--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -163,7 +163,6 @@ Result.class_eval do
       end
     end
 
-
     vulnerabilities.each do |v|
 
       r = find_duplicate_vulnerability(v, options)
@@ -274,7 +273,6 @@ Result.class_eval do
 
       end
     end
-
 
     update_vulnerability_counts if update_counts
 
@@ -427,6 +425,10 @@ Result.class_eval do
     when "file"
       # This is a static analyzer match for file and github event monitor
       return existing_vulnerabilities.select{|v| v["file_name"] == vulnerability.file_name && v["code_fragment"] == vulnerability.code_fragment && v["term"] == vulnerability.term }
+    when "source_code"
+      # This is a static analyzer match for any static analyzer which has
+      # source_code_line, source_code_file, and type
+      return existing_vulnerabilities.select{|v| v["source_code_file"] == vulnerability.source_code_file && v["source_code_line"] == vulnerability.source_code_line && v["type"] == vulnerability.type}
     when "path"
       # This is a static analyzer match for paths
       return existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["term"] == vulnerability.term}

--- a/lib/scumblr_tasks/security/python_analyzer.rb
+++ b/lib/scumblr_tasks/security/python_analyzer.rb
@@ -88,9 +88,7 @@ end
 class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
 
   def perform_work(result_id)
-                      require 'byebug'
-        byebug
-        puts 1
+
     r = Result.find(result_id)
 
     if(r.metadata.try(:[],"configuration").try(:[],"bandit").try(:[],"disabled") == true)

--- a/lib/scumblr_tasks/security/python_analyzer.rb
+++ b/lib/scumblr_tasks/security/python_analyzer.rb
@@ -32,30 +32,30 @@ class ScumblrTask::PythonAnalyzer < ScumblrTask::AsyncSidekiq
 
   def self.options
     return super.merge({
-      :saved_result_filter=> {name: "Result Filter",
-                              description: "Only run endpoint analyzer matching the given filter",
-                              required: true,
-                              type: :saved_result_filter
-                              },
-      :key_suffix => {name: "Key Suffix",
-                      description: "Provide a key suffix for testing out experimental regularz expressions",
-                      required: false,
-                      type: :string
-                      },
-      :confidence_level => {name: "Confidence Level",
-                            description: "Confidence level to include in results",
-                            required: false,
-                            type: :choice,
-                            default: :High,
-                            choices: [:High, :Medium, :Low]
-                            },
-      :severity_level => {name: "Severity Level",
-                          description: "Severity level to include in results",
-                          required: false,
-                          type: :choice,
-                          default: :High,
-                          choices: [:High, :Medium, :Low]
-                          }
+                         :saved_result_filter=> {name: "Result Filter",
+                                                 description: "Only run endpoint analyzer matching the given filter",
+                                                 required: true,
+                                                 type: :saved_result_filter
+                                                 },
+                         :key_suffix => {name: "Key Suffix",
+                                         description: "Provide a key suffix for testing out experimental regularz expressions",
+                                         required: false,
+                                         type: :string
+                                         },
+                         :confidence_level => {name: "Confidence Level",
+                                               description: "Confidence level to include in results",
+                                               required: false,
+                                               type: :choice,
+                                               default: :High,
+                                               choices: [:High, :Medium, :Low]
+                                               },
+                         :severity_level => {name: "Severity Level",
+                                             description: "Severity level to include in results",
+                                             required: false,
+                                             type: :choice,
+                                             default: :High,
+                                             choices: [:High, :Medium, :Low]
+                                             }
     })
   end
 
@@ -65,10 +65,10 @@ class ScumblrTask::PythonAnalyzer < ScumblrTask::AsyncSidekiq
 
   def self.config_options
     {:downloads_tmp_dir =>{ name: "Repo Download Location",
-      description: "Location to download repos. Defaults to /tmp/python_analyzer",
-      required: false
-      }
-    }
+                            description: "Location to download repos. Defaults to /tmp/python_analyzer",
+                            required: false
+                            }
+     }
   end
 
   def initialize(options={})
@@ -122,12 +122,12 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
         end
 
         status = Timeout::timeout(600) do
-        Rails.logger.info "Scanning"
+          Rails.logger.info "Scanning"
           scan_with_bandit(repo_local_path).each do |scan_result|
-          Rails.logger.info "Parsing results"
+            Rails.logger.info "Parsing results"
 
             scan_result["results"].each do |issue|
-            Rails.logger.info "Creating vulnerabilities"
+              Rails.logger.info "Creating vulnerabilities"
               vuln = Vulnerability.new
               vuln.type = issue["issue_text"].to_s
               vuln.task_id = @options[:_self]
@@ -146,12 +146,12 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
                 vuln.url = r.url + "/blob/master/" + vuln.source_code_file
               end
 
-              vuln.match_location = "path"
+              vuln.match_location = ""
 
               # If we have code samples, try to get the right line numbers
               if issue.try(:[], "code")
                 vuln.source_code = get_relevant_source(@temp_path + issue["filename"].to_s.gsub(@temp_path, ""), vuln.source_code_line.to_i)
-                vuln.match_location = "file"
+                vuln.match_location = "source_code"
               end
 
               vuln.confidence_level = issue["issue_confidence"].to_s
@@ -170,14 +170,24 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
         r.metadata["python_results"]["git_repo"] = git_url
         r.metadata["python_results"]["results_date"] = Time.now.to_s
         if !findings.empty?
-          r.update_vulnerabilities(findings)
-        end
-        Rails.logger.info "Updating and saving"
 
-        #if r.changed?
-          r.save!
-        #end
-      Rails.logger.info "Saved"
+          # After we update vulnerabilities, collecdt a list of vuln ids
+          # which are either new or existing.
+          vuln_ids, vuln_metrics = r.update_vulnerabilities(findings)
+
+          # Loop through the existing vulnerabilities, skip if it's new or existing
+          # Vulns that aren't found anymore and were identified with the same task
+          # Mark as remedaited.
+          r.metadata["vulnerabilities"].each_with_object({}) do |vuln|
+            unless vuln_ids.include? vuln["id"] and vuln["task_id"] == @options[:_self].id.to_s
+              vuln["status"] = "Remediated"
+            end
+          end
+        end
+
+        Rails.logger.info "Updating and saving"
+        r.save
+        Rails.logger.info "Saved"
       end
       #now that we're done with it, delete the cloned repo
     ensure
@@ -229,11 +239,11 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
     end
 
     the_hits = {
-        :hit_line_number => line_no,
-        :hit_source_line => matched_line,
-        :before => before,
-        :after => after
-      }
+      :hit_line_number => line_no,
+      :hit_source_line => matched_line,
+      :before => before,
+      :after => after
+    }
   end
 
   def scan_with_bandit(local_repo_path)
@@ -270,17 +280,17 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
     else
       pid, status = Process::waitpid2(pid)
       status_code = status.exitstatus
-    ensure
-      [stdin, stdout, stderr].each { |io| io.close if !io.nil? && !io.closed? }
+      ensure
+        [stdin, stdout, stderr].each { |io| io.close if !io.nil? && !io.closed? }
+      end
+
+
+      parsed_results = JSON.parse(data.strip) rescue nil
+      if !parsed_results.nil?
+        results.push parsed_results
+      end
+
+      return results
     end
 
-
-    parsed_results = JSON.parse(data.strip) rescue nil
-    if !parsed_results.nil?
-      results.push parsed_results
-    end
-
-    return results
   end
-
-end

--- a/lib/scumblr_tasks/security/rails_analyzer.rb
+++ b/lib/scumblr_tasks/security/rails_analyzer.rb
@@ -37,30 +37,30 @@ class ScumblrTask::RailsAnalyzer < ScumblrTask::Base
 
   def self.options
     return super.merge({
-      :saved_result_filter=> {name: "Result Filter",
-                              description: "Only run endpoint analyzer matching the given filter",
-                              required: false,
-                              type: :saved_result_filter
-                              },
-      :key_suffix => {name: "Key Suffix",
-                      description: "Provide a key suffix for testing out experimental regular expressions",
-                      required: false,
-                      type: :string
-                      },
-      :confidence_level => {name: "Confidence Level",
-                            description: "Confidence level to include in results",
-                            required: false,
-                            type: :choice,
-                            default: :High,
-                            choices: [:High, :Medium, :Weak, :Informational]
-                            },
-      :severity => {name: "Severity",
-                    description: "Severity to include in results",
-                    required: false,
-                    type: :choice,
-                    default: :High,
-                    choices: [:Critical, :High, :Medium, :Low, :Informational]
-                    }
+                         :saved_result_filter=> {name: "Result Filter",
+                                                 description: "Only run endpoint analyzer matching the given filter",
+                                                 required: false,
+                                                 type: :saved_result_filter
+                                                 },
+                         :key_suffix => {name: "Key Suffix",
+                                         description: "Provide a key suffix for testing out experimental regular expressions",
+                                         required: false,
+                                         type: :string
+                                         },
+                         :confidence_level => {name: "Confidence Level",
+                                               description: "Confidence level to include in results",
+                                               required: false,
+                                               type: :choice,
+                                               default: :High,
+                                               choices: [:High, :Medium, :Weak, :Informational]
+                                               },
+                         :severity => {name: "Severity",
+                                       description: "Severity to include in results",
+                                       required: false,
+                                       type: :choice,
+                                       default: :High,
+                                       choices: [:Critical, :High, :Medium, :Low, :Informational]
+                                       }
     })
   end
 
@@ -107,10 +107,10 @@ class ScumblrTask::RailsAnalyzer < ScumblrTask::Base
 
   def self.config_options
     {:downloads_tmp_dir =>{ name: "Repo Download Location",
-      description: "Location to download repos. Defaults to /tmp/rails_analyzer",
-      required: false
-      }
-    }
+                            description: "Location to download repos. Defaults to /tmp/rails_analyzer",
+                            required: false
+                            }
+     }
   end
 
   def initialize(options={})
@@ -159,11 +159,11 @@ class ScumblrTask::RailsAnalyzer < ScumblrTask::Base
     end
 
     the_hits = {
-        :hit_line_number => line_no,
-        :hit_source_line => matched_line,
-        :before => before,
-        :after => after
-      }
+      :hit_line_number => line_no,
+      :hit_source_line => matched_line,
+      :before => before,
+      :after => after
+    }
   end
 
   def tokenize_command(cmd)
@@ -211,204 +211,214 @@ class ScumblrTask::RailsAnalyzer < ScumblrTask::Base
         else
           pid, status = Process::waitpid2(pid)
           status_code = status.exitstatus
-        ensure
-          [stdin, stdout, stderr].each { |io| io.close if !io.nil? && !io.closed? }
-        end
-
-
-
-        if(status_code == 127)
-          begin
-            pid, stdin, stdout, stderr = popen4("brakeman", "#{fixedPath}", "-o", "#{fixedPath}/output.json")
-          rescue
-            status_code = 127
-          else
-            pid, status = Process::waitpid2(pid)
-            status_code = status.exitstatus
           ensure
             [stdin, stdout, stderr].each { |io| io.close if !io.nil? && !io.closed? }
           end
 
+
+
           if(status_code == 127)
-            @no_brakeman_installation ||= false
-            create_error("[-] No Brakeman executable found. Make sure brakeman or brakeman-pro is in Scumblr's path. Will continue trying to run bundler audit") unless @no_brakeman_installation
-            @no_brakeman_installation = true
-          end
-        end
-
-        report = File.read("#{fixedPath}/output.json")
-        report = JSON.parse(report).merge({"railspath"=>fixedPath})
-        results.push report
-      else
-        create_event("There is no app folder in #{railspath}.", "Warn")
-
-      end
-    end
-    return results
-  end
-
-  def scan_with_bundler_audit(local_repo_path)
-    results = []
-
-    paths = find_path(local_repo_path, "Gemfile.lock", 1)
-
-    paths.each do |gemfile_path|
-      if gemfile_path.start_with?(@temp_path) && gemfile_path.end_with?("Gemfile.lock")
-        scanner = Bundler::Audit::Scanner.new(gemfile_path.strip.gsub("Gemfile.lock", ""))
-        res = scanner.scan
-        res.each do |issue|
-          if issue.is_a?(Bundler::Audit::Scanner::UnpatchedGem)
-            vuln = {gem: issue.gem.name, version: issue.gem.version.to_s, title: issue.advisory.title, cve: issue.advisory.cve, cvss_v2: issue.advisory.cvss_v2, details: issue.advisory.description.to_s }
-          elsif issue.is_a?(Bundler::Audit::Scanner::InsecureSource)
-            vuln = {title: "Remote gem with insecure (non-TLS) URI #{issue.source}", cvss_v2: 5.5, details: "" }
-          end
-          results.push vuln
-        end
-      end
-    end
-    return results
-  end
-
-  def perform_work(r)
-    if(r.metadata.try(:[],"configuration").try(:[],"brakeman").try(:[],"disabled") == true)
-      return nil
-    end
-    repo_local_path = ""
-    unless (r.metadata.try(:[], "repository_data").present? && r.metadata["repository_data"].try(:[], "ssh_clone_url").present?)
-      create_error("No URL for result: #{r.id.to_s}")
-    else
-      git_url = r.metadata["repository_data"]["ssh_clone_url"]
-      Rails.logger.info "Cloning and scanning #{git_url}"
-      findings = []
-      begin
-        @semaphore.synchronize {
-        status = Timeout::timeout(600) do
-          #download the repo so we can scan it
-          #local_repo_path = download_repo(stash_git_url, r.url)
-          if git_url != ""
-            tmp_download_folder = r.url.split("/")[3]
-          end
-
-          repo_local_path = "#{@temp_path}#{git_url.split('/').last.gsub(/\.git$/,"")}#{r.id}"
-          dsd = RepoDownloader.new(git_url, repo_local_path)
-          dsd.download
-        end
-        }
-        #Brakeman hangs when scanning some repos, normally a scan takes less than 5 seconds
-        #We'll give it a minute before we kill it
-        @semaphore.synchronize {
-        status = Timeout::timeout(100) do
-          scan_with_brakeman(repo_local_path).each do |scan_result|
-            scan_result["warnings"].each do |warning|
-              #Only worry about the confidence level and above that was
-              #chosen by the user
-              confidence_levels = case @options[:confidence_level].to_s
-              when "High"
-                ["High"]
-              when "Medium"
-                ["High", "Medium"]
-              when "Weak"
-                ["High", "Medium", "Weak"]
-              else
-                ["High", "Medium", "Weak", "Info"]
-              end
-
-              if confidence_levels.include?(warning["confidence"].to_s.strip)
-                vuln = Vulnerability.new
-                vuln.match_location = "fingerprint"
-                vuln.type = warning["warning_type"].to_s
-                vuln.fingerprint = warning["fingerprint"]
-                vuln.source_code_file = warning["file"].to_s
-                vuln.source_code_line = warning["line"].to_s
-                vuln.source_code = get_relevant_source(scan_result["railspath"] + "/" + warning["file"].to_s, warning["line"].to_i)
-                vuln.task_id = @options[:_self].id.to_s
-                if(@options[:key_suffix].present?)
-                  vuln.key_suffix = @options[:key_suffix]
-                end
-
-                vuln.details = warning["message"].to_s
-
-                if warning["confidence"] == "Info"
-                  confidence = "Informational"
-                else
-                  confidence = warning["confidence"]
-                end
-
-                vuln.confidence_level = vuln.severity = confidence
-                vuln.source = "Brakeman"
-                findings.push vuln
-              end
-            end
-          end
-        end
-        }
-
-        @semaphore.synchronize {
-        status = Timeout::timeout(10) do
-          scan_with_bundler_audit(repo_local_path).each do |scan_result|
-            criticality_levels = []
-            if @options[:severity].to_s == "Critical"
-              criticality_levels = ["Critical"]
-            elsif @options[:severity].to_s == "High"
-              criticality_levels = ["Critical", "High"]
-            elsif @options[:severity].to_s == "Medium"
-              criticality_levels = ["Critical", "High", "Medium"]
-            elsif @options[:severity].to_s == "Low"
-              criticality_levels = ["Critical", "High", "Medium", "Low"]
+            begin
+              pid, stdin, stdout, stderr = popen4("brakeman", "#{fixedPath}", "-o", "#{fixedPath}/output.json")
+            rescue
+              status_code = 127
             else
-              criticality_levels = ["Critical", "High", "Medium", "Low", "Informational"]
+              pid, status = Process::waitpid2(pid)
+              status_code = status.exitstatus
+              ensure
+                [stdin, stdout, stderr].each { |io| io.close if !io.nil? && !io.closed? }
+              end
+
+              if(status_code == 127)
+                @no_brakeman_installation ||= false
+                create_error("[-] No Brakeman executable found. Make sure brakeman or brakeman-pro is in Scumblr's path. Will continue trying to run bundler audit") unless @no_brakeman_installation
+                @no_brakeman_installation = true
+              end
             end
 
-            severity = ""
-            if scan_result[:cvss_v2].to_f > 9
-              severity = "Critical"
-            elsif scan_result[:cvss_v2].to_f > 7.5
-              severity = "High"
-            elsif scan_result[:cvss_v2].to_f > 4
-              severity = "Medium"
-            elsif scan_result[:cvss_v2].to_f >  1
-              severity = "Low"
-            else scan_result[:cvss_v2].to_f
-              severity = "Informational"
-            end
+            report = File.read("#{fixedPath}/output.json")
+            report = JSON.parse(report).merge({"railspath"=>fixedPath})
+            results.push report
+          else
+            create_event("There is no app folder in #{railspath}.", "Warn")
 
-            if criticality_levels.include?(severity)
-              vuln = Vulnerability.new
-              vuln.type = scan_result[:title].to_s
-              vuln.severity = severity
-              vuln.source = "Bundler Audit"
-              vuln.details = scan_result[:details].to_s
-              findings.push vuln
+          end
+        end
+        return results
+      end
+
+      def scan_with_bundler_audit(local_repo_path)
+        results = []
+
+        paths = find_path(local_repo_path, "Gemfile.lock", 1)
+
+        paths.each do |gemfile_path|
+          if gemfile_path.start_with?(@temp_path) && gemfile_path.end_with?("Gemfile.lock")
+            scanner = Bundler::Audit::Scanner.new(gemfile_path.strip.gsub("Gemfile.lock", ""))
+            res = scanner.scan
+            res.each do |issue|
+              if issue.is_a?(Bundler::Audit::Scanner::UnpatchedGem)
+                vuln = {gem: issue.gem.name, version: issue.gem.version.to_s, title: issue.advisory.title, cve: issue.advisory.cve, cvss_v2: issue.advisory.cvss_v2, details: issue.advisory.description.to_s }
+              elsif issue.is_a?(Bundler::Audit::Scanner::InsecureSource)
+                vuln = {title: "Remote gem with insecure (non-TLS) URI #{issue.source}", cvss_v2: 5.5, details: "" }
+              end
+              results.push vuln
             end
           end
         end
-        }
-      rescue Exception => e
-        create_event("#{e.message} \n#{e.backtrace}", "Warn")
-      ensure
-        begin
-          r.metadata["rails_analyzer"] = true
-          r.metadata["rails_results"] ||= {}
-          r.metadata["rails_results"]["latest"] ||= {}
-          r.metadata["rails_results"]["git_repo"] = git_url
-          r.metadata["rails_results"]["results_date"] = Time.now.to_s
-          if !findings.empty?
-            r.update_vulnerabilities(findings)
+        return results
+      end
+
+      def perform_work(r)
+        if(r.metadata.try(:[],"configuration").try(:[],"brakeman").try(:[],"disabled") == true)
+          return nil
+        end
+        repo_local_path = ""
+        unless (r.metadata.try(:[], "repository_data").present? && r.metadata["repository_data"].try(:[], "ssh_clone_url").present?)
+          create_error("No URL for result: #{r.id.to_s}")
+        else
+          git_url = r.metadata["repository_data"]["ssh_clone_url"]
+          Rails.logger.info "Cloning and scanning #{git_url}"
+          findings = []
+          begin
+            @semaphore.synchronize {
+              status = Timeout::timeout(600) do
+                #download the repo so we can scan it
+                #local_repo_path = download_repo(stash_git_url, r.url)
+                if git_url != ""
+                  tmp_download_folder = r.url.split("/")[3]
+                end
+
+                repo_local_path = "#{@temp_path}#{git_url.split('/').last.gsub(/\.git$/,"")}#{r.id}"
+                dsd = RepoDownloader.new(git_url, repo_local_path)
+                dsd.download
+              end
+            }
+            #Brakeman hangs when scanning some repos, normally a scan takes less than 5 seconds
+            #We'll give it a minute before we kill it
+            @semaphore.synchronize {
+              status = Timeout::timeout(100) do
+                scan_with_brakeman(repo_local_path).each do |scan_result|
+                  scan_result["warnings"].each do |warning|
+                    #Only worry about the confidence level and above that was
+                    #chosen by the user
+                    confidence_levels = case @options[:confidence_level].to_s
+                    when "High"
+                      ["High"]
+                    when "Medium"
+                      ["High", "Medium"]
+                    when "Weak"
+                      ["High", "Medium", "Weak"]
+                    else
+                      ["High", "Medium", "Weak", "Info"]
+                    end
+
+                    if confidence_levels.include?(warning["confidence"].to_s.strip)
+                      vuln = Vulnerability.new
+                      vuln.match_location = "fingerprint"
+                      vuln.type = warning["warning_type"].to_s
+                      vuln.fingerprint = warning["fingerprint"]
+                      vuln.source_code_file = warning["file"].to_s
+                      vuln.source_code_line = warning["line"].to_s
+                      vuln.source_code = get_relevant_source(scan_result["railspath"] + "/" + warning["file"].to_s, warning["line"].to_i)
+                      vuln.task_id = @options[:_self].id.to_s
+                      if(@options[:key_suffix].present?)
+                        vuln.key_suffix = @options[:key_suffix]
+                      end
+
+                      vuln.details = warning["message"].to_s
+
+                      if warning["confidence"] == "Info"
+                        confidence = "Informational"
+                      else
+                        confidence = warning["confidence"]
+                      end
+
+                      vuln.confidence_level = vuln.severity = confidence
+                      vuln.source = "Brakeman"
+                      findings.push vuln
+                    end
+                  end
+                end
+              end
+            }
+
+            @semaphore.synchronize {
+              status = Timeout::timeout(10) do
+                scan_with_bundler_audit(repo_local_path).each do |scan_result|
+                  criticality_levels = []
+                  if @options[:severity].to_s == "Critical"
+                    criticality_levels = ["Critical"]
+                  elsif @options[:severity].to_s == "High"
+                    criticality_levels = ["Critical", "High"]
+                  elsif @options[:severity].to_s == "Medium"
+                    criticality_levels = ["Critical", "High", "Medium"]
+                  elsif @options[:severity].to_s == "Low"
+                    criticality_levels = ["Critical", "High", "Medium", "Low"]
+                  else
+                    criticality_levels = ["Critical", "High", "Medium", "Low", "Informational"]
+                  end
+
+                  severity = ""
+                  if scan_result[:cvss_v2].to_f > 9
+                    severity = "Critical"
+                  elsif scan_result[:cvss_v2].to_f > 7.5
+                    severity = "High"
+                  elsif scan_result[:cvss_v2].to_f > 4
+                    severity = "Medium"
+                  elsif scan_result[:cvss_v2].to_f >  1
+                    severity = "Low"
+                  else scan_result[:cvss_v2].to_f
+                    severity = "Informational"
+                  end
+
+                  if criticality_levels.include?(severity)
+                    vuln = Vulnerability.new
+                    vuln.type = scan_result[:title].to_s
+                    vuln.severity = severity
+                    vuln.source = "Bundler Audit"
+                    vuln.details = scan_result[:details].to_s
+                    findings.push vuln
+                  end
+                end
+              end
+            }
+          rescue Exception => e
+            create_event("#{e.message} \n#{e.backtrace}", "Warn")
+          ensure
+            begin
+              r.metadata["rails_analyzer"] = true
+              r.metadata["rails_results"] ||= {}
+              r.metadata["rails_results"]["latest"] ||= {}
+              r.metadata["rails_results"]["git_repo"] = git_url
+              r.metadata["rails_results"]["results_date"] = Time.now.to_s
+              if !findings.empty?
+                # After we update vulnerabilities, collecdt a list of vuln ids
+                # which are either new or existing.
+                vuln_ids, vuln_metrics = r.update_vulnerabilities(findings)
+
+                # Loop through the existing vulnerabilities, skip if it's new or existing
+                # Vulns that aren't found anymore and were identified with the same task
+                # Mark as remedaited.
+
+                r.metadata["vulnerabilities"].each_with_object({}) do |vuln|
+                  unless vuln_ids.include? vuln["id"] and vuln["task_id"].to_s == @options[:_self].id.to_s
+                    vuln["status"] = "Remediated"
+                  end
+                end
+              end
+              r.save
+              #now that we're done with it, delete the cloned repo
+              if Dir.exists?(repo_local_path)
+                FileUtils.rm_rf(repo_local_path)
+              end
+            rescue Exception => e
+              create_error("#{e.message} \n#{e.backtrace}")
+            end
           end
-          #if r.changed?
-            r.save!
-          #end
-          #now that we're done with it, delete the cloned repo
-          if Dir.exists?(repo_local_path)
-            FileUtils.rm_rf(repo_local_path)
-          end
-        rescue Exception => e
-          create_error("#{e.message} \n#{e.backtrace}")
         end
       end
+
+
+
     end
-  end
-
-
-
-end


### PR DESCRIPTION
This code adds auto-deduplication of static analysis findings based on source_code_file, source_code_line, and type of finding.  

Secondarily, by keeping track of what vulnerabilities are new or existing, we can remove vulneralbities associated with a task which are no longer found.  Support for `auto-remediation` was added to both Bandit and Brakeman static analyzers.  

