### PR TITLE
fixes git_url for repo downloader

### DIFF
--- a/lib/scumblr_tasks/security/python_analyzer.rb
+++ b/lib/scumblr_tasks/security/python_analyzer.rb
@@ -117,8 +117,13 @@ class ScumblrWorkers::PythonAnalyzerWorker < ScumblrWorkers::AsyncSidekiqWorker
 
           repo_local_path = "#{@temp_path}#{git_url.split('/').last.gsub(/\.git$/,"")}#{r.id}"
           Rails.logger.info "Cloning to #{repo_local_path}"
-          dsd = RepoDownloader.new("git_url", repo_local_path)
-          dsd.download
+          begin
+            dsd = RepoDownloader.new(git_url, repo_local_path)
+            dsd.download
+          rescue
+            create_event("#{r.id} is not found, mark repo as deprecated repo.", "WARN")
+            return
+          end
         end
 
         status = Timeout::timeout(600) do


### PR DESCRIPTION
When debugging this analyzer, we accidentally quoted the variable which holds the git_url.  I've gone ahead and updated that. 

In addition, I wrapped the download helper in begin/rescue to help give us an idea of how stale our python projects are.  I noticed that many of the repos based on our Saved Filters are removed.  One strategy may be to tag them as Deprecated