### PR TITLE
Catch localfile sketchy exceptions

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -640,7 +640,8 @@ class ResultsController < ApplicationController
   end
 
   def update_screenshot
-    unless params[:job_status].present? and params[:job_status] == "FAILURE"
+    # If we're in a failed state (aka localhost files), stop execution 
+    unless params[:sketch_url].present? and params[:sketch_url].to_s.includes? "127.0.0.1"
       if(params[:sketch_url].present?)
         sketch_url = params[:sketch_url]
         if(params[:token].present? && !params[:sketch_url].match(/\Ahttps?:\/\/s3.amazonaws.com/))


### PR DESCRIPTION
It looks like if Sketchy is used as a Callback system, even failed jobs show up as successful as long as the callback works.  This is odd and should be fixed.  In the short term, we can skip over results which have localhost as their file asset locations, which would indicate a bad sketchy scrape or screenshot.  