### PR TITLE
loosen vuln deduplication matching to prevent edge cases

### DIFF
--- a/lib/helpers/vulnerability_helpers.rb
+++ b/lib/helpers/vulnerability_helpers.rb
@@ -421,14 +421,14 @@ Result.class_eval do
     case vulnerability.match_location
     when "content"
       # This is a static analyzer match for content
-      return existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["code_fragment"] == vulnerability.code_fragment && v["term"] == vulnerability.term }
+      return existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["term"] == vulnerability.term }
     when "file"
       # This is a static analyzer match for file and github event monitor
-      return existing_vulnerabilities.select{|v| v["file_name"] == vulnerability.file_name && v["code_fragment"] == vulnerability.code_fragment && v["term"] == vulnerability.term }
+      return existing_vulnerabilities.select{|v| v["file_name"] == vulnerability.file_name && v["term"] == vulnerability.term }
     when "source_code"
       # This is a static analyzer match for any static analyzer which has
       # source_code_line, source_code_file, and type
-      return existing_vulnerabilities.select{|v| v["source_code_file"] == vulnerability.source_code_file && v["source_code_line"] == vulnerability.source_code_line && v["type"] == vulnerability.type}
+      return existing_vulnerabilities.select{|v| v["source_code_file"] == vulnerability.source_code_file && v["type"] == vulnerability.type}
     when "path"
       # This is a static analyzer match for paths
       return existing_vulnerabilities.select{|v| v["url"] == vulnerability.url && v["term"] == vulnerability.term}


### PR DESCRIPTION
Our vuln de-duper was way too aggressive.  In some circumstances, a developer simply adding a new line would throw of the de-duper.  This creates a bit of leniency in how we match duplicates.  